### PR TITLE
Fix typo in organization readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,6 +2,6 @@
 
 Kellnr is a free and open-source registry for [Rust](https://www.rust-lang.org/) crates. Think of [crates.io](https://crates.io/), but on your own hardware for your private crates.
 
-You can finde more information about Kellnr on our official [Kellne Webpage](https://kellnr.io/).
+You can finde more information about Kellnr on our official [Kellnr Webpage](https://kellnr.io/).
 
 This GitHub organisation contains all the code, blog post and more related to the development of Kellnr.


### PR DESCRIPTION
I was actually looking to fix a typo on your website, but didn't find a repo for it. I noticed another typo in the org readme though 😛 